### PR TITLE
updated learner arguments

### DIFF
--- a/bin/feed.js
+++ b/bin/feed.js
@@ -33,7 +33,7 @@ dbinit({
 
     var lines = 0;
 
-    var learn = learner(db, {inBatch: true});
+    var learn = learner(db, config.ai);
     db.batch.begin();
 
     var past = Date.now() - 30 * 24 * 3600 * 1000; // 30 days


### PR DESCRIPTION
Replaced the obsolete inBatch argument for learner by config.ai so that the proper keyword threshold is used when feeding